### PR TITLE
Fix bug that allows `check_rate` to be called 2x in sequence even if the bucket limit is 1 attempt per hour

### DIFF
--- a/lib/hammer/backend.ex
+++ b/lib/hammer/backend.ex
@@ -10,6 +10,7 @@ defmodule Hammer.Backend do
   @callback count_hit(
               pid :: pid(),
               key :: bucket_key,
+              scale_ms :: integer,
               now :: integer
             ) ::
               {:ok, count :: integer}
@@ -18,6 +19,7 @@ defmodule Hammer.Backend do
   @callback count_hit(
               pid :: pid(),
               key :: bucket_key,
+              scale_ms :: integer,
               now :: integer,
               increment :: integer
             ) ::

--- a/lib/hammer/utils.ex
+++ b/lib/hammer/utils.ex
@@ -17,9 +17,7 @@ defmodule Hammer.Utils do
   # Returns tuple of {timestamp, key}, where key is {bucket_number, id}
   def stamp_key(id, scale_ms) do
     stamp = timestamp()
-    # with scale_ms = 1 bucket changes every millisecond
-    bucket_number = trunc(stamp / scale_ms)
-    key = {bucket_number, id}
+    key = {scale_ms, id}
     {stamp, key}
   end
 

--- a/test/hammer_ets_test.exs
+++ b/test/hammer_ets_test.exs
@@ -23,9 +23,9 @@ defmodule ETSTest do
   test "count_hit", context do
     pid = context[:pid]
     {stamp, key} = Utils.stamp_key("one", 200_000)
-    assert {:ok, 1} = ETS.count_hit(pid, key, stamp)
-    assert {:ok, 2} = ETS.count_hit(pid, key, stamp)
-    assert {:ok, 3} = ETS.count_hit(pid, key, stamp)
+    assert {:ok, 1} = ETS.count_hit(pid, key, 200_000, stamp)
+    assert {:ok, 2} = ETS.count_hit(pid, key, 200_000, stamp)
+    assert {:ok, 3} = ETS.count_hit(pid, key, 200_000, stamp)
   end
 
   test "get_bucket", context do
@@ -34,10 +34,10 @@ defmodule ETSTest do
     # With no hits
     assert {:ok, nil} = ETS.get_bucket(pid, key)
     # With one hit
-    assert {:ok, 1} = ETS.count_hit(pid, key, stamp)
+    assert {:ok, 1} = ETS.count_hit(pid, key, 200_000, stamp)
     assert {:ok, {{_, "two"}, 1, _, _}} = ETS.get_bucket(pid, key)
     # With two hits
-    assert {:ok, 2} = ETS.count_hit(pid, key, stamp)
+    assert {:ok, 2} = ETS.count_hit(pid, key, 200_000, stamp)
     assert {:ok, {{_, "two"}, 2, _, _}} = ETS.get_bucket(pid, key)
   end
 
@@ -47,9 +47,9 @@ defmodule ETSTest do
     # With no hits
     assert {:ok, 0} = ETS.delete_buckets(pid, "three")
     # With three hits in same bucket
-    assert {:ok, 1} = ETS.count_hit(pid, key, stamp)
-    assert {:ok, 2} = ETS.count_hit(pid, key, stamp)
-    assert {:ok, 3} = ETS.count_hit(pid, key, stamp)
+    assert {:ok, 1} = ETS.count_hit(pid, key, 200_000, stamp)
+    assert {:ok, 2} = ETS.count_hit(pid, key, 200_000, stamp)
+    assert {:ok, 3} = ETS.count_hit(pid, key, 200_000, stamp)
     assert {:ok, 1} = ETS.delete_buckets(pid, "three")
   end
 
@@ -57,7 +57,7 @@ defmodule ETSTest do
     pid = context[:pid]
     expiry_ms = context[:expiry_ms]
     {stamp, key} = Utils.stamp_key("something-pruned", 200_000)
-    assert {:ok, 1} = ETS.count_hit(pid, key, stamp)
+    assert {:ok, 1} = ETS.count_hit(pid, key, 200_000, stamp)
     assert {:ok, {{_, "something-pruned"}, 1, _, _}} = ETS.get_bucket(pid, key)
     :timer.sleep(expiry_ms * 5)
     assert {:ok, nil} = ETS.get_bucket(pid, key)


### PR DESCRIPTION
When `check_rate` is called, it's expected that `ms_to_next_bucket` should be qual to `scale_ms`, but that's not the case at the moment due to:

1.`Utils.stamp_key/2` is currently creating a variable bucket key for the same ID and `scale_ms`. The bucket key changes every `scale_ms` milliseconds.
2. Redis/ETS backends are not expiring the bucket key after `scale_ms`, instead they rely that a new key is provided (1)

This bug allows `check_rate` to be called 2x in sequence even if the bucket limit is 1 attempt per hour. Both calls could receive `allow` if timed when the bucket is about to expire.

This MR fixes this issue by:

1. Returning a fixed key on `Utils.stamp_key/2` for the same bucket ID and `scale_ms`
2. Changing the Redis/ETS backends to expire the bucket after `scale_ms`